### PR TITLE
Updated grafana/helm.md: Typo in the command used to expose grafana svc

### DIFF
--- a/Installation/Grafana/helm.md
+++ b/Installation/Grafana/helm.md
@@ -14,4 +14,4 @@
 
 ## Expose Grafana Service
 
-`kubectl expose service grafana — type=NodePort — target-port=3000 — name=grafana-ext`
+`kubectl expose service grafana —-type=NodePort —-target-port=3000 —-name=grafana-ext`


### PR DESCRIPTION
There was a typo in the last command in helm.md . This is the command that Ive edited.
 kubectl expose service grafana --type=NodePort --target-port=3000 --name=grafana-ext